### PR TITLE
Make patch-like commits refer to actual section in yellow paper

### DIFF
--- a/10/README.md
+++ b/10/README.md
@@ -8,9 +8,30 @@ editor: Stewart Mackenzie <setori88@gmail.com>
 
 The Monetary Policy Release
 
-| Block Number | Applied RFCs |
-| ------------ | ------------ |
-| 1150000 | [4/FEE](https://sjmackenzie.gitbooks.io/rfc/spec:4/FEE) |
-| 2500000 | [5/FEE](https://sjmackenzie.gitbooks.io/rfc/spec:5/FEE) |
-| 3000000 | [6/REPLAY](https://sjmackenzie.gitbooks.io/rfc/spec:6/REPLAY), [7/FEE](https://sjmackenzie.gitbooks.io/rfc/spec:7/FEE), [8/DIFF](https://sjmackenzie.gitbooks.io/rfc/spec:8/DIFF) |
-| 5000000 | [12/MP](https://sjmackenzie.gitbooks.io/rfc/spec:12/MP)
+Until we are able to move sections of the yellow paper, please refer
+to EIP-150 revision for a core specification of the protocol.
+
+Note that things below should apply:
+
+* The blocks, state and transaction specification should be referred
+  from `8/DIFF`.
+* The virtual machine specification should be referred from
+  `13/OPCODE`.
+* Block finalization, regarding to mining rewards, should be referred
+  from `12/MP`.
+
+## Hard Forks
+
+Below are hard forks applied in this blockchain:
+
+* Block number 0
+  * Transaction signing: `14/TRASIG`.
+  * Fee schedule: `3/FEE`.
+* Block number 1150000
+  * Transaction signing: `15/TRASIG`.
+  * Fee schedule: `4/FEE`.
+* Block number 2500000
+  * Fee schedule: `5/FEE`.
+* Block number 3000000
+  * Transaction signing: `6/TRASIG`.
+  * Fee schedule: `7/FEE`.

--- a/12/README.md
+++ b/12/README.md
@@ -1,104 +1,16 @@
 ---
 domain: rfc.ethereumclassic.org
 shortname: 12/MP
-name: Monetary Policy and Final Modification to the Ethereum Classic Emission Schedule
+name: Ethereum Block Finalisation with Monetary Policy
 status: draft
 editor: Matthew Mazur <5n4pr011@gmail.com>
 ---
 
-### Abstract
+See `explanation.md` for details of this RFC.
 
-This ECIP proposes a solution to the Ethereum Classic Monetary Policy to adjust, with finality, the current emission schedule implementation of 14.0625ETC per block in perpetuity. The solution proposed introduces a theoretical upper bound on the maximum absolute number of ETC and introduces a method of degraded emission over time.
+## Changes
 
+Compared with the EIP-150 revision of the yellow paper in section 11,
+changes are:
 
-### Motivation
-
-At its core, the purpose of adjusting the current monetary policy of the ETC network, to a policy which places an upper bound on the number of tokens issued and decreases the rate at which ETC is introduced into the system over time, is to "bootstrap" the network’s security. By increasing the security of the network, a proper monetary policy indirectly nurtures the network, providing a secure platform for which smart contract development will be more likely to occur.
-
-If we accept that speculation, a demand function, is the main economic driver of any new system, that the Ethereum Classic Network is a new system, and that speculation will drive the value of the Ethereum Classic token until the utility value of the Ethereum Classic token exceeds its speculative value, it is reasonable to assume that rewarding speculation will help to secure and nurture the network:
-
-Large scale, high risk, and/or high profile applications will be less likely to be developed on a blockchain with weak security ie. a low hashrate. Increasing demand for the Ethereum Classic token will, all else being equal, increase the price of the Ethereum Classic token.  An increase in the price of the token incentivizes mining operations to direct their efforts on the Ethereum Classic Network or to begin operations on the Ethereum Classic Network. The additional mining power that is directed towards the network, because of this incentive, further secures the network. An increase in the security of the network assists in building trust between the network and both current and potential users and developers of the network. This increase of trust in the network provides an incentive for large scale, high risk, and/or high profile applications to be developed on the network. Thus, rewarding speculation helps to secure and nurture the Ethereum Classic network.
-
-Especially important to early stage cryptocurrencies, assuming all other variables are equal, a network with a decreasing rate of production and an upper bound on the number of tokens that will be issued will provide more incentive for high risk speculation to occur than one without a known rate of production or an upper bound.
-
-Above all, it is important to recognize that a monetary policy does not directly create value for the network. A stable platform with useful applications and a vibrant community are the variables that drive value. The purpose of a properly structured monetary policy is to create an incentive for people to take a risk on a system that has not yet reached its full potential, providing an additional reason for those who may not otherwise be interested, who cannot or have not developed anything on the platform (yet), or who remain skeptical, to involve themselves in an otherwise nascent platform.
-
-<br />
-
-### Specification
-
-#### Current Ethereum Classic Monetary Policy
-
-[Source](http://ethdocs.org/en/latest/mining.html)
-
-![image alt text](ETC_MP_Perpetual.png)
-
-The current mining rewards on the Ethereum Classic Network are as follows:
-
-* A "static" block reward for the winning block of 5 ETC
-
-* An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.15625ETC) per uncle included, up to a maximum of two (2) uncles.
-
-* A reward of up to 7/8 (4.375ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
-
-* This reward structure is set to continue in perpetuity.
-
-<br />
-
-#### Proposed Ethereum Classic Monetary Policy
-
-[Source](https://docs.google.com/spreadsheets/d/1Fs_RNEPSRJxP22PZmwxWjiulVVcu5Ic1GvBXCPCt9to/edit?usp=sharing)
-
-![image alt text](ETC_MP_5M20.png)
-
-*An "Era" is defined as the number of blocks containing a given production rate.*
-
-The proposed mining rewards on the Ethereum Classic Network are as follows:
-
-* Era 1 (blocks 1 - 5,000,000)
-
-    * A "static" block reward for the winning block of 5 ETC
-
-    * An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.15625ETC) per uncle included, up to a maximum of two (2) uncles.
-
-    * A reward of up to 7/8 of the winning block reward (4.375ETC) for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
-
-* Era 2 (blocks 5,000,001 - 10,000,000)
-
-    * A "static" block reward for the winning block of 4 ETC
-
-    * An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.125ETC) per uncle included, up to a maximum of two (2) uncles.
-
-    * A reward of 1/32 (0.125ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
-
-    * Era 2 represents a reduction of 20% of Era 1 values, while also reducing uncle rewards to uncle miners to be the same value as the reward to the winning miner for including the uncle(s).
-
-* Era 3+
-
-    * All rewards will be reduced at a constant rate of 20% upon entering a new Era.
-
-    * Every Era will last for 5,000,000 blocks.
-
-<br />
-
-### Rationale
-
-Why this 5M20 model:
-
-* Minimizes making the first adjustment too "exceptional." Other than equalizing all uncle rewards at block 5M, the changes/reductions to supply over time are equal.
-
-* The model is easy to understand. Every 5M blocks, total reward is reduced by 20%.
-
-* Uncle inclusion rates through block 5M will likely remain at around the 5%. Because of this, once block 5M is reached, in the worst case scenario (supply wise, which assumes two uncles included every block in perpetuity) the total supply will not exceed 210.7M ETC. Should the network remain as efficient in its ability to propagate found blocks as it has in Era 1 (5.4% uncle rate), the total supply will not be less than 198.5M ETC. This provides for an incentive to miners and client developers to maintain high standards and maintenance of their hardware and software they introduce into the network.
-
-* The 5M model provides a balance between providing an acceptable depreciating distribution rate for rewarding high risk investment into the system and maintaining an active supply production over time. Maintaining this future supply rate keeps the potential price of the ethereum token suppressed enough to ensure transaction prices can remain lower than if the supply were to reduce to zero at an earlier date. This serves as a "blow off valve" for price increases in the case that a dynamic gas model cannot be implemented for the foreseeable future.
-
-* Having the monetary policy begin at 5M provides a balance between delaying the implementation to provide enough time for code development and testing, and accelerating the implementation to provide an incentive to potential early adopters and high risk investors. Based on community discussion, beginning before block 4M is too soon for development, testing, and implementation of the policy, and later than block 6M is too long to interest many potential early adopters/investors.
-
-* Not changing the monetary policy of ETC provides no benefit to risk taking early on in the life of the system, speculation wise. It will be difficult for the network to bootstrap its security. While bitcoin has what is considered to be the generally accepted ideal monetary policy, with its 50% reduction every four years, this model is not likely to yield optimal investment for ETC. If ETC were to adopt the bitcoin halving model, it is arguable that too much of the supply would be produced too soon: 50% of the estimated total ETC supply would be mined 75% sooner than traditional bitcoin because of the pre-mine of 72M ETC that was initially created in the genesis block. While the 5M model does not completely eliminate the effects of the premine, since 50% of total estimated production occurs sooner than would the bitcoin model, it makes up for this, to an extent, with its lengthening of the time until 90%, 99% and 100% of bitcoin are mined. The tail end of ETC production is longer and wider than bitcoin.
-
-* In the current ETC reward schedule, the total reward for uncles is higher than the reward received by the miner who also includes uncles. In this state, a miner is significantly diluting the value of his reward by including these uncled blocks. By equalizing the rewards to uncle block miners with the rewards to miners who include an uncle block, the reward structure is more fairly distributed. In addition, equalizing the uncle rewards reduces the incentive for miners to set up an ETC "uncle farm," and instead drives them to better secure the network by competing for the latest "real block."
-
-* Because the rate at which uncled blocks can vary with extreme, reducing the reward for uncle blocks assists considerably with being able to forecast the true upper bound of the total ETC that will ultimately exist in the system.
-
-* The model is the best attempt at balancing the needs to incentivize high risk investment into the system in order to bootstrap security and create a potential user base, be easy to understand, include a reduction to the rate of production of ETC over time, include an upper bound on supply, provide for a long term production of the ETC token, and allow enough time for development, adoption, and awareness.
+* Equation (147), (148), (149) and (150).

--- a/12/explanation.md
+++ b/12/explanation.md
@@ -1,0 +1,96 @@
+### Abstract
+
+This ECIP proposes a solution to the Ethereum Classic Monetary Policy to adjust, with finality, the current emission schedule implementation of 14.0625ETC per block in perpetuity. The solution proposed introduces a theoretical upper bound on the maximum absolute number of ETC and introduces a method of degraded emission over time.
+
+
+### Motivation
+
+At its core, the purpose of adjusting the current monetary policy of the ETC network, to a policy which places an upper bound on the number of tokens issued and decreases the rate at which ETC is introduced into the system over time, is to "bootstrap" the network’s security. By increasing the security of the network, a proper monetary policy indirectly nurtures the network, providing a secure platform for which smart contract development will be more likely to occur.
+
+If we accept that speculation, a demand function, is the main economic driver of any new system, that the Ethereum Classic Network is a new system, and that speculation will drive the value of the Ethereum Classic token until the utility value of the Ethereum Classic token exceeds its speculative value, it is reasonable to assume that rewarding speculation will help to secure and nurture the network:
+
+Large scale, high risk, and/or high profile applications will be less likely to be developed on a blockchain with weak security ie. a low hashrate. Increasing demand for the Ethereum Classic token will, all else being equal, increase the price of the Ethereum Classic token.  An increase in the price of the token incentivizes mining operations to direct their efforts on the Ethereum Classic Network or to begin operations on the Ethereum Classic Network. The additional mining power that is directed towards the network, because of this incentive, further secures the network. An increase in the security of the network assists in building trust between the network and both current and potential users and developers of the network. This increase of trust in the network provides an incentive for large scale, high risk, and/or high profile applications to be developed on the network. Thus, rewarding speculation helps to secure and nurture the Ethereum Classic network.
+
+Especially important to early stage cryptocurrencies, assuming all other variables are equal, a network with a decreasing rate of production and an upper bound on the number of tokens that will be issued will provide more incentive for high risk speculation to occur than one without a known rate of production or an upper bound.
+
+Above all, it is important to recognize that a monetary policy does not directly create value for the network. A stable platform with useful applications and a vibrant community are the variables that drive value. The purpose of a properly structured monetary policy is to create an incentive for people to take a risk on a system that has not yet reached its full potential, providing an additional reason for those who may not otherwise be interested, who cannot or have not developed anything on the platform (yet), or who remain skeptical, to involve themselves in an otherwise nascent platform.
+
+<br />
+
+### Specification
+
+#### Current Ethereum Classic Monetary Policy
+
+[Source](http://ethdocs.org/en/latest/mining.html)
+
+![image alt text](ETC_MP_Perpetual.png)
+
+The current mining rewards on the Ethereum Classic Network are as follows:
+
+* A "static" block reward for the winning block of 5 ETC
+
+* An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.15625ETC) per uncle included, up to a maximum of two (2) uncles.
+
+* A reward of up to 7/8 (4.375ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
+
+* This reward structure is set to continue in perpetuity.
+
+<br />
+
+#### Proposed Ethereum Classic Monetary Policy
+
+[Source](https://docs.google.com/spreadsheets/d/1Fs_RNEPSRJxP22PZmwxWjiulVVcu5Ic1GvBXCPCt9to/edit?usp=sharing)
+
+![image alt text](ETC_MP_5M20.png)
+
+*An "Era" is defined as the number of blocks containing a given production rate.*
+
+The proposed mining rewards on the Ethereum Classic Network are as follows:
+
+* Era 1 (blocks 1 - 5,000,000)
+
+    * A "static" block reward for the winning block of 5 ETC
+
+    * An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.15625ETC) per uncle included, up to a maximum of two (2) uncles.
+
+    * A reward of up to 7/8 of the winning block reward (4.375ETC) for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
+
+* Era 2 (blocks 5,000,001 - 10,000,000)
+
+    * A "static" block reward for the winning block of 4 ETC
+
+    * An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.125ETC) per uncle included, up to a maximum of two (2) uncles.
+
+    * A reward of 1/32 (0.125ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
+
+    * Era 2 represents a reduction of 20% of Era 1 values, while also reducing uncle rewards to uncle miners to be the same value as the reward to the winning miner for including the uncle(s).
+
+* Era 3+
+
+    * All rewards will be reduced at a constant rate of 20% upon entering a new Era.
+
+    * Every Era will last for 5,000,000 blocks.
+
+<br />
+
+### Rationale
+
+Why this 5M20 model:
+
+* Minimizes making the first adjustment too "exceptional." Other than equalizing all uncle rewards at block 5M, the changes/reductions to supply over time are equal.
+
+* The model is easy to understand. Every 5M blocks, total reward is reduced by 20%.
+
+* Uncle inclusion rates through block 5M will likely remain at around the 5%. Because of this, once block 5M is reached, in the worst case scenario (supply wise, which assumes two uncles included every block in perpetuity) the total supply will not exceed 210.7M ETC. Should the network remain as efficient in its ability to propagate found blocks as it has in Era 1 (5.4% uncle rate), the total supply will not be less than 198.5M ETC. This provides for an incentive to miners and client developers to maintain high standards and maintenance of their hardware and software they introduce into the network.
+
+* The 5M model provides a balance between providing an acceptable depreciating distribution rate for rewarding high risk investment into the system and maintaining an active supply production over time. Maintaining this future supply rate keeps the potential price of the ethereum token suppressed enough to ensure transaction prices can remain lower than if the supply were to reduce to zero at an earlier date. This serves as a "blow off valve" for price increases in the case that a dynamic gas model cannot be implemented for the foreseeable future.
+
+* Having the monetary policy begin at 5M provides a balance between delaying the implementation to provide enough time for code development and testing, and accelerating the implementation to provide an incentive to potential early adopters and high risk investors. Based on community discussion, beginning before block 4M is too soon for development, testing, and implementation of the policy, and later than block 6M is too long to interest many potential early adopters/investors.
+
+* Not changing the monetary policy of ETC provides no benefit to risk taking early on in the life of the system, speculation wise. It will be difficult for the network to bootstrap its security. While bitcoin has what is considered to be the generally accepted ideal monetary policy, with its 50% reduction every four years, this model is not likely to yield optimal investment for ETC. If ETC were to adopt the bitcoin halving model, it is arguable that too much of the supply would be produced too soon: 50% of the estimated total ETC supply would be mined 75% sooner than traditional bitcoin because of the pre-mine of 72M ETC that was initially created in the genesis block. While the 5M model does not completely eliminate the effects of the premine, since 50% of total estimated production occurs sooner than would the bitcoin model, it makes up for this, to an extent, with its lengthening of the time until 90%, 99% and 100% of bitcoin are mined. The tail end of ETC production is longer and wider than bitcoin.
+
+* In the current ETC reward schedule, the total reward for uncles is higher than the reward received by the miner who also includes uncles. In this state, a miner is significantly diluting the value of his reward by including these uncled blocks. By equalizing the rewards to uncle block miners with the rewards to miners who include an uncle block, the reward structure is more fairly distributed. In addition, equalizing the uncle rewards reduces the incentive for miners to set up an ETC "uncle farm," and instead drives them to better secure the network by competing for the latest "real block."
+
+* Because the rate at which uncled blocks can vary with extreme, reducing the reward for uncle blocks assists considerably with being able to forecast the true upper bound of the total ETC that will ultimately exist in the system.
+
+* The model is the best attempt at balancing the needs to incentivize high risk investment into the system in order to bootstrap security and create a potential user base, be easy to understand, include a reduction to the rate of production of ETC over time, include an upper bound on supply, provide for a long term production of the ETC token, and allow enough time for development, adoption, and awareness.

--- a/13/README.md
+++ b/13/README.md
@@ -1,0 +1,17 @@
+---
+domain: rfc.ethereumclassic
+shortname: 13/OPCODE
+name: Ethereum Virtual Machine
+status: stable
+editor: Wei Tang <hi@that.world>
+---
+
+The [EIP-150 revision](http://gavwood.com/paper.pdf) of the yellow
+paper is used. This RFC refers to the Appendix H.
+
+Until we are able to move the section of the yellow paper to
+here. Those following things should be noted:
+
+* If a call asks for more gas than the maximum allowed amount, do not
+  return an OOG error; instead, call with the maximum allowed amount
+  of gas.

--- a/14/README.md
+++ b/14/README.md
@@ -1,0 +1,13 @@
+---
+domain: rfc.ethereumclassic
+shortname: 14/TRASIG
+name: Signing Transactions
+status: deprecated
+editor: Wei Tang <hi@that.world>
+---
+
+The [EIP-150 revision](http://gavwood.com/paper.pdf) of the yellow
+paper is used. This RFC refers to the Appendix F.
+
+This is the original version of the transaction signing, without
+validity check.

--- a/15/README.md
+++ b/15/README.md
@@ -1,0 +1,16 @@
+---
+domain: rfc.ethereumclassic
+shortname: 15/TRASIG
+name: Signing Transactions
+status: stable
+editor: Wei Tang <hi@that.world>
+---
+
+The [EIP-150 revision](http://gavwood.com/paper.pdf) of the yellow
+paper is used. This RFC refers to the Appendix F.
+
+## Changes
+
+Compared with `14/TRASIG`:
+
+* Validity check is applied.

--- a/3/README.md
+++ b/3/README.md
@@ -6,25 +6,11 @@ status: deprecated
 editor: Wei Tang <hi@that.world>
 ---
 
-## Hard Fork
+## Fee Schedule
 
-The paper includes a few sections about hard forked version of the
-protocol. Developers should note that those sections does not
-generally apply from block number 0 in all current main Ethereum
-blockchains.
-
-### Homestead
-
-The paper talked about the homestead hard fork, thus everything
-related to it and the $$N_H$$ variable will only work after the
-homestead hard fork block. This also includes the signature validity
-check in Appendix F.
-
-### Fee Schedule
-
-The paper's Appendix G is updated to always refer to the newest fee
-schedule. Here we attach the fee schedule that should be applied from
-block number 0 in Ethereum and Ethereum Classic mainnet.
+The Yellow Paper's Appendix G is updated to always refer to the newest
+fee schedule. Here we attach the fee schedule that should be applied
+from block number 0 in Ethereum and Ethereum Classic mainnet.
 
 | Name | Value | Description |
 | ---- | ----- | ----------- |
@@ -63,3 +49,7 @@ block number 0 in Ethereum and Ethereum Classic mainnet.
 | `G_sha3word` | 6 | Paid for each word (rounded up) for input data to a `SHA3` operation. |
 | `G_copy` | 2 | Partial payment for `*COPY` operations, multiplied by words copied, rounded up. |
 | `G_blockhash` | 20 | Payment for `BLOCKHASH` operation. |
+
+## Gas Cost
+
+As the fee constants have been determinted, this RFC should also specify the gas cost algorithms to be executed. The currently should refer to the EIP-150 revision of the yellow paper.

--- a/4/README.md
+++ b/4/README.md
@@ -10,12 +10,52 @@ This refers to the homestead hard-fork. The EIP can be found
 at
 [EIP-2](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.mediawiki).
 
+## Changes
+
+Fees below has changed, compared with `3/FEE`.
+
+* The gas cost for creating contracts via a transaction is increased from 21000 to 53000. The value `G_txcreate` is used to document the increase.
+
 ## Fee Schedule
 
-Fees below has changed:
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| `G_zero` | 0 | Nothing paid for operations of the set `W_zero` |
+| `G_base` | 2 | Amount of gas to pay for operations of the set `W_base`. |
+| `G_verylow` | 3 | Amount of gas to pay for operations of the set `W_verylow`. |
+| `G_low` | 5 | Amount of gas to pay for operations of the set `W_low`. |
+| `G_mid` | 8 | Amount of gas to pay for operations of the set `W_mid`. |
+| `G_high` | 10 | Amount of gas to pay for operations of the set `W_high`. |
+| `G_extcode` | 20 | Amount of gas to pay for operations of the set `W_extcode`. |
+| `G_balance` | 400 | Amount of gas to pay for a BALANCE operation. |
+| `G_sload` | 50 | Paid for a `SLOAD` operation. |
+| `G_jumpdest` | 1 | Paid for a `JUMPDEST` operation. |
+| `G_sset` | 20000 | Paid for an `SSTORE` operation when the storage value is set to non-zero from zero. |
+| `G_sreset` | 5000 | Paid for an `SSTORE` operation when the storage value's zeroness remains unchanged or is set to zero. |
+| `R_sclear` | 15000 | Refund given (added into refund counter) when the storage value is set to zero from non-zero. |
+| `R_suicide` | 24000 | Refund given (added into refund counter) for suiciding an account. |
+| `G_suicide` | 5000 | Amount of gas to pay for a SUICIDE operation. |
+| `G_create` | 32000 | Paid for a `CREATE` operation. |
+| `G_codedeposit` | 200 | Paid per byte for a `CREATE` operation to succeed in placing code into state. |
+| `G_call` | 40 | Paid for a `CALL` operation. |
+| `G_callvalue` | 9000 | Paid for a non-zero value transfer as part of the `CALL` operation. |
+| `G_callstipend` | 2300 | A stipend for the called contract subtracted from `G_callvalue` for a non-zero value transfer. |
+| `G_newaccount` | 25000 | Paid for a `CALL` operation to a not previously excisting account. |
+| `G_exp` | 10 | Partial payment for an `EXP` operation. |
+| `G_expbyte` | 10 | Partial payment for the `EXP` operation. |
+| `G_memory` | 3 | Paid for every additional word when expanding memory. |
+| `G_txcreate` | 32000 |  Paid by all contract-creating transactions after the Homestead transition. |
+| `G_txdatazero` | 4 | Paid for every zero byte of data or code for a transaction. |
+| `G_txdatanonzero` | 68 | Paid for every non-zero byte of data or code for a transaction. |
+| `G_transaction` | 21000 | Paid for every transaction. |
+| `G_log` | 375 | Partial payment for a `LOG` operation. |
+| `G_logdata` | 8 | Paid for each byte in a `LOG` operation's data. |
+| `G_logtopic` | 375 | Paid for each topic of a `LOG` operation. |
+| `G_sha3` | 30 | Paid for each `SHA3` operation. |
+| `G_sha3word` | 6 | Paid for each word (rounded up) for input data to a `SHA3` operation. |
+| `G_copy` | 2 | Partial payment for `*COPY` operations, multiplied by words copied, rounded up. |
+| `G_blockhash` | 20 | Payment for `BLOCKHASH` operation. |
 
-* The gas cost for creating contracts via a transaction is increased from 21000 to 53000.
+## Gas Cost
 
-## Yellow Paper
-
-In `3/YP`, sections about homestead now applies.
+As the fee constants have been determinted, this RFC should also specify the gas cost algorithms to be executed. The currently should refer to the EIP-150 revision of the yellow paper.

--- a/5/README.md
+++ b/5/README.md
@@ -10,9 +10,9 @@ This refers to the IO-gas cost change hard fork. The EIP can be found
 at
 [EIP-150](https://github.com/ethereum/EIPs/issues/150).
 
-## Fee Schedule
+## Changes
 
-Fees below has changed:
+Fees below has changed, compared with `4/FEE`.
 
 * Increase the gas cost of EXTCODESIZE to 700
 * Increase the base gas cost of EXTCODECOPY to 700
@@ -23,3 +23,11 @@ Fees below has changed:
 * Increase the recommended gas limit target to 5.5 million
 * If a call asks for more gas than the maximum allowed amount, do not return an OOG error; instead, call with the maximum allowed amount of gas
 * If SUICIDE hits a newly created account, it triggers an additional gas cost of 25000 (similar to CALLs)
+
+## Fee Schedule
+
+(The fee schedule table will be computed later.)
+
+## Gas Cost
+
+As the fee constants have been determinted, this RFC should also specify the gas cost algorithms to be executed. The currently should refer to the EIP-150 revision of the yellow paper.

--- a/6/README.md
+++ b/6/README.md
@@ -1,7 +1,7 @@
 ---
 domain: rfc.ethereumclassic
-shortname: 6/REPLAY
-name: Simple Replay Attach Protection
+shortname: 6/TRASIG
+name: Signing Transactions with Simple Replay Attach Protection
 status: stable
 editor: Wei Tang <hi@that.world>
 ---
@@ -9,10 +9,13 @@ editor: Wei Tang <hi@that.world>
 This refers to the replay attack protection hard fork. The EIP can be
 found at [EIP-155](https://github.com/ethereum/EIPs/issues/155).
 
-If `block.number >= FORK_BLKNUM` and `v = CHAIN_ID * 2 + 35` or `v =
-CHAIN_ID * 2 + 36`, then when computing the hash of a transaction for
-purposes of signing or recovering, instead of hashing only the first
-six elements (ie. nonce, gasprice, startgas, to, value, data), hash
-nine elements, with v replaced by CHAIN_ID, r = 0 and s = 0. The
-currently existing signature scheme using v = 27 and v = 28 remains
-valid and continues to operate under the same rules as it does now.
+## Changes
+
+Compared with `15/TRASIG`, if `block.number >= FORK_BLKNUM` and `v =
+CHAIN_ID * 2 + 35` or `v = CHAIN_ID * 2 + 36`, then when computing the
+hash of a transaction for purposes of signing or recovering, instead
+of hashing only the first six elements (ie. nonce, gasprice, startgas,
+to, value, data), hash nine elements, with v replaced by CHAIN_ID, r =
+0 and s = 0. The currently existing signature scheme using v = 27 and
+v = 28 remains valid and continues to operate under the same rules as
+it does now.

--- a/7/README.md
+++ b/7/README.md
@@ -9,7 +9,16 @@ editor: Wei Tang <hi@that.world>
 This refers to the EXP cost increase hard fork. The EIP can be found
 at [EIP-160](https://github.com/ethereum/EIPs/issues/160).
 
+## Changes
+
+Compared with `6/FEE`, if `block.number >= FORK_BLKNUM`, increase the
+gas cost of EXP from 10 + 10 per byte in the exponent to 10 + 50 per
+byte in the exponent.
+
 ## Fee Schedule
 
-If `block.number >= FORK_BLKNUM`, increase the gas cost of EXP from
-10 + 10 per byte in the exponent to 10 + 50 per byte in the exponent.
+(The fee schedule table will be computed later.)
+
+## Gas Cost
+
+As the fee constants have been determinted, this RFC should also specify the gas cost algorithms to be executed. The currently should refer to the EIP-150 revision of the yellow paper.

--- a/8/README.md
+++ b/8/README.md
@@ -29,14 +29,11 @@ block_diff = parent_diff
       + int(2**explosion)
 ````
 
-With this changes min difficulty value will become:
-* Block 2,500,000 == 2**23 == 8,388,608
-* Block 3,000,000 == 2**28 == 268,435,456
-* Block 4,000,000 == 2**28 == 268,435,456
-* Block 5,000,000 == 2**28 == 268,435,456
-* Block 5,200,000 == 2**30 == 1 TH
-* Block 6,000,000 == 2**38 == 274 TH
+Using constants:
 
-## Links
-
-Difficulty growth model: https://docs.google.com/spreadsheets/d/1ZXNrSCNV0HGWU7zOTUyIIRUGv5M44P6wiAZclpY4Y2Q/edit
+````
+pause_block = 3000000 //15 Jan 2017
+cont_block = 5000000 //15 Dec 2017
+delay = (cont_block - pause_block) / 100000 //20
+fixed_diff = (pause_block / 100000) - 2 //28
+````

--- a/8/README.md
+++ b/8/README.md
@@ -1,80 +1,20 @@
 ---
 domain: rfc.ethereumclassic
 shortname: 8/DIFF
-name: Delay Difficulty Bomb Explosion
+name: Ethereum Blocks, State and Transaction with Difficulty Bomb Delay
 status: stable
 editor: Igor Artamonov <splix@ethereumclassic.org>
 ---
 
 Derived
 from
-[ECIP1010](https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1010.md).
+[ECIP1010](https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1010.md). See
+`explanation.md` for details about this RFC.
 
-## Abstract
+## Changes
 
-This ECIP describes the details of delaying Difficulty Bomb growth for one year. It’s suggested to change Difficulty Bomb formula to stop growing for period of time from January 2017 to December 2017, which is around blocks 3,000,000 and 5,000,000 accordingly.
+Compared with the EIP-150 revision of the yellow paper, equation (39) should be replaced by:
 
-## Motivation
-
-For the next phase of Ethereum Classic it’s planned to make a set of updates that could possible break backward compatibility and make serious changes to Ethereum Classic economic model. It includes changes to Monetary Policy, PoW/PoS or Hybrid, Replay Attack, DAG growths and Difficulty Bomb itself. All of these topics are important and must be solved as soon as possible.
-
-Such changes to the protocol can cause another fork, and it’s very dangerous to introduce just part of protocol changes at this moment. It’s very likely that after the Difficulty Bomb will be diffused it will be near impossible to make any other changes to the protocol. That is one of the main reasons why Difficulty Bomb was introduced initially.
-
-To reduce risk of a potential fork during protocol upgrades and to keep development resources focused on working on the next phase of the Ethereum Classic, it seems reasonable to implement Difficulty Bomb diffusion at the very last step in the series of protocol upgrades.
-
-Most of this upgrades to the protocol requires significant time for finding optimal model, implementation and testing. It’s too reckless to make this changes without proper validation. With optimistic estimations it requires at least 6 months, which is not giving us enough time before Difficulty Explosion moment. Also consider the fact that this is an estimation for the ideal situation.
-
-One of the most feasible solutions at this moment will be delaying difficulty growth to the moment when all other changes will be ready to use.
-
-Delaying the Difficulty Bomb is a trivial change to the protocol. It keeps all the logic on place, just adds a pause in X blocks to stop difficulty growing for a some period of time. If we choose 2,000,000 blocks, it will a pause it for about a year, which will give us time to implement and test all protocol upgrades for the next version.
-
-## Specification
-
-Current formula for a minimal difficulty is
-
-````
-block_diff = parent_diff
-     + parent_diff / 2048 * max(1 - (block_timestamp - parent_timestamp) / 10, -99)
-     + int(2**((block.number / 100000) - 2))
-````
-
-The most important part related to Difficulty Bomb is:
-
-````
-2**((block.number / 100000) - 2)
-````
-
-It’s a lower bound for minimal difficulty, which grows exponentially with next step every 100,000 blocks. `-2` is added to start growth only after the block 200,000
-
-With this formula minimal difficulty is:
-* Block 1 == 2**(-2) == 0
-* Block 100,000 == 2**(-1) == 0
-* Block 200,000 == 2**0 == 1
-* Block 300,000 == 2**1 == 2
-* Block 1,920,000 == 2**17 == 131,072
-* Block 2,000,000 == 2**18 == 262,144
-* Block 2,500,000 == 2**23 == 8,388,608
-* Block 3,000,000 == 2**28 == 268,435,456
-* Block 4,000,000 == 2**38 == 274,877,906,944 or 274 GH
-* Block 5,000,000 == 2**48 == 281 TH
-* Block 5,200,000 == 2**50 == 1126 TH
-* Block 6,000,000 == 2**58 == 288230 TH
-
-Current difficulty used for mining is 8 TH. For a comparison, difficulty in Forked ETH Blockchain is 71 TH.
-
-To pause difficulty growth `(block.number / 100000) - 2` must be fixed to a concrete value for the range 3,000,000 to 5,000,000, then continue growing.
-
-Instead of value `2` it’s proposed to use `n` with a dynamic formula as following:
-
-Constants:
-````
-pause_block = 3000000 //15 Jan 2017
-cont_block = 5000000 //15 Dec 2017
-delay = (cont_block - pause_block) / 100000 //20
-fixed_diff = (pause_block / 100000) - 2 //28
-````
-
-Final formula:
 ````
 if (block.number < pause_block) {
     explosion = (block.number / 100000) - 2    

--- a/8/explanation.md
+++ b/8/explanation.md
@@ -1,0 +1,90 @@
+## Abstract
+
+This ECIP describes the details of delaying Difficulty Bomb growth for one year. It’s suggested to change Difficulty Bomb formula to stop growing for period of time from January 2017 to December 2017, which is around blocks 3,000,000 and 5,000,000 accordingly.
+
+## Motivation
+
+For the next phase of Ethereum Classic it’s planned to make a set of updates that could possible break backward compatibility and make serious changes to Ethereum Classic economic model. It includes changes to Monetary Policy, PoW/PoS or Hybrid, Replay Attack, DAG growths and Difficulty Bomb itself. All of these topics are important and must be solved as soon as possible.
+
+Such changes to the protocol can cause another fork, and it’s very dangerous to introduce just part of protocol changes at this moment. It’s very likely that after the Difficulty Bomb will be diffused it will be near impossible to make any other changes to the protocol. That is one of the main reasons why Difficulty Bomb was introduced initially.
+
+To reduce risk of a potential fork during protocol upgrades and to keep development resources focused on working on the next phase of the Ethereum Classic, it seems reasonable to implement Difficulty Bomb diffusion at the very last step in the series of protocol upgrades.
+
+Most of this upgrades to the protocol requires significant time for finding optimal model, implementation and testing. It’s too reckless to make this changes without proper validation. With optimistic estimations it requires at least 6 months, which is not giving us enough time before Difficulty Explosion moment. Also consider the fact that this is an estimation for the ideal situation.
+
+One of the most feasible solutions at this moment will be delaying difficulty growth to the moment when all other changes will be ready to use.
+
+Delaying the Difficulty Bomb is a trivial change to the protocol. It keeps all the logic on place, just adds a pause in X blocks to stop difficulty growing for a some period of time. If we choose 2,000,000 blocks, it will a pause it for about a year, which will give us time to implement and test all protocol upgrades for the next version.
+
+## Specification
+
+Current formula for a minimal difficulty is
+
+````
+block_diff = parent_diff
+     + parent_diff / 2048 * max(1 - (block_timestamp - parent_timestamp) / 10, -99)
+     + int(2**((block.number / 100000) - 2))
+````
+
+The most important part related to Difficulty Bomb is:
+
+````
+2**((block.number / 100000) - 2)
+````
+
+It’s a lower bound for minimal difficulty, which grows exponentially with next step every 100,000 blocks. `-2` is added to start growth only after the block 200,000
+
+With this formula minimal difficulty is:
+* Block 1 == 2**(-2) == 0
+* Block 100,000 == 2**(-1) == 0
+* Block 200,000 == 2**0 == 1
+* Block 300,000 == 2**1 == 2
+* Block 1,920,000 == 2**17 == 131,072
+* Block 2,000,000 == 2**18 == 262,144
+* Block 2,500,000 == 2**23 == 8,388,608
+* Block 3,000,000 == 2**28 == 268,435,456
+* Block 4,000,000 == 2**38 == 274,877,906,944 or 274 GH
+* Block 5,000,000 == 2**48 == 281 TH
+* Block 5,200,000 == 2**50 == 1126 TH
+* Block 6,000,000 == 2**58 == 288230 TH
+
+Current difficulty used for mining is 8 TH. For a comparison, difficulty in Forked ETH Blockchain is 71 TH.
+
+To pause difficulty growth `(block.number / 100000) - 2` must be fixed to a concrete value for the range 3,000,000 to 5,000,000, then continue growing.
+
+Instead of value `2` it’s proposed to use `n` with a dynamic formula as following:
+
+Constants:
+````
+pause_block = 3000000 //15 Jan 2017
+cont_block = 5000000 //15 Dec 2017
+delay = (cont_block - pause_block) / 100000 //20
+fixed_diff = (pause_block / 100000) - 2 //28
+````
+
+Final formula:
+````
+if (block.number < pause_block) {
+    explosion = (block.number / 100000) - 2    
+} else if (block.number < cont_block) {
+    explosion = fixed_diff
+} else { // block.number >= cont_block    
+    explosion = (block.number / 100000) - delay - 2
+}
+
+block_diff = parent_diff
+      + parent_diff / 2048 * max(1 - (block_timestamp - parent_timestamp) / 10, -99)
+      + int(2**explosion)
+````
+
+With this changes min difficulty value will become:
+* Block 2,500,000 == 2**23 == 8,388,608
+* Block 3,000,000 == 2**28 == 268,435,456
+* Block 4,000,000 == 2**28 == 268,435,456
+* Block 5,000,000 == 2**28 == 268,435,456
+* Block 5,200,000 == 2**30 == 1 TH
+* Block 6,000,000 == 2**38 == 274 TH
+
+## Links
+
+Difficulty growth model: https://docs.google.com/spreadsheets/d/1ZXNrSCNV0HGWU7zOTUyIIRUGv5M44P6wiAZclpY4Y2Q/edit

--- a/9/README.md
+++ b/9/README.md
@@ -10,8 +10,28 @@ The Die Hard Release
 
 https://www.youtube.com/watch?v=pEOVNmSR7_c
 
-| Block Number | Applied RFCs |
-| ------------ | ------------ |
-| 1150000 | [4/FEE](https://sjmackenzie.gitbooks.io/rfc/spec:4/FEE) |
-| 2500000 | [5/FEE](https://sjmackenzie.gitbooks.io/rfc/spec:5/FEE) |
-| 3000000 | [6/REPLAY](https://sjmackenzie.gitbooks.io/rfc/spec:6/REPLAY), [7/FEE](https://sjmackenzie.gitbooks.io/rfc/spec:7/FEE), [8/DIFF](https://sjmackenzie.gitbooks.io/rfc/spec:8/DIFF) |
+Until we are able to move sections of the yellow paper, please refer
+to EIP-150 revision for a core specification of the protocol.
+
+Note that things below should apply:
+
+* The blocks, state and transaction specification should be referred
+  from `8/DIFF`.
+* The virtual machine specification should be referred from
+  `13/OPCODE`.
+  
+## Hard Forks
+
+Below are hard forks applied in this blockchain:
+
+* Block number 0
+  * Transaction signing: `14/TRASIG`.
+  * Fee schedule: `3/FEE`.
+* Block number 1150000
+  * Transaction signing: `15/TRASIG`.
+  * Fee schedule: `4/FEE`.
+* Block number 2500000
+  * Fee schedule: `5/FEE`.
+* Block number 3000000
+  * Transaction signing: `6/TRASIG`.
+  * Fee schedule: `7/FEE`.


### PR DESCRIPTION
Until we are able to move sections of the yellow paper to RFCs due to licensing issue, this is probably something we can do best -- provide links to yellow paper and then specify changes based on one particular revision.

See commits for other changes.