### PR TITLE
Problem: gitbook-coss rendering bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 Ethereum Classic RFC
 ====================
 
+[![Build Status](https://jenkins.that.world/buildStatus/icon?job=Ethereum Classic RFC)](https://jenkins.that.world/job/Ethereum Classic RFC)
+
 This is the Ethereum Classic RFC project.
 
 We collect specifications for APIs, file formats, protocols, processes and compositions of RFCs which result in a blockchain soft forks.
 
 You can start contributing by sending a pull request to https://github.com/ethereumproject/rfc on GitHub.
 
-Please [read this](https://sjmackenzie.gitbooks.io/rfc/content/) for the rendered content.
+Please [read this](https://etcrfc.that.world) for the rendered content.
 
 ## Guidelines
 


### PR DESCRIPTION
Fix #9. Additionally, it uses a Jenkin build server to automatically build this repo, so we don't need to pull changes back to sjmackenzie.gitbooks.io to make it appear.