### PR TITLE
Modify 2.3.7 git commit spec

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -66,7 +66,36 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 1. A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
 1. A patch SHALL NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
 1. A patch MUST compile cleanly and pass project self-tests on at least the principle target platform.
-1. A patch commit message MUST consist of a single short (less than 50 characters) line stating the problem ("Problem: ...") being solved, followed by a blank line and then the proposed solution ("Solution: ...").
+1. A patch commit message MUST consist of a single short (less than 50 characters) line stating the subject of changes and MUST be followed by a blank line, followed by an OPTIONAL paragraph describing changes in detail (if present, succeeded too by a MANDATORY blank line), followed by a MANDATORY description of the reason for the change ("Problem: ..."). Subsequent pontifications and references are OPTIONAL. _eg._
+```
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical (unless
+you omit the body entirely); various tools like `log`, `shortlog`
+and `rebase` can get confused if you run the two together.
+
+Problem: Explain the problem that this commit is solving. Focus on why you
+are making this change as opposed to how (the code explains that).
+Are there side effects or other unintuitive consequences of this
+change? Here's the place to explain them.
+
+Further paragraphs come after blank lines.
+
+ - Bullet points are okay, too
+
+ - Typically a hyphen or asterisk is used for the bullet, preceded
+   by a single space, with blank lines in between, but conventions
+   vary here
+
+If you use an issue tracker, put references to them at the bottom,
+like this:
+
+Resolves: #123
+See also: #456, #789
+```
 1. A "Correct Patch" is one that satisfies the above requirements.
 
 ### 2.4. Development Process


### PR DESCRIPTION
```
Propose alternative commit message standard in 2.3.7, or, Problem: 'Problem:' is a problem

Proposed change adheres to informal git commit message spec outlined and
exemplified here: https://chris.beams.io/posts/git-commit/

Problem: Reiterating 'Problem:' at the beginning each commit message is redundant and
seems upside-down. I find it far more useful to browse commit messages
when they headline their change instead of the problem (any problem has
many ways toward a solution)... it's a little like if every cookbook
were titled "I'm Hungry," instead of "Cooking Hamburgers."
```

And, along these lines, I wonder if it might also be worth (re?)considering the pattern of `module/othermodule: Made changes to stuff`, where `module` and `othermodule` reference the impacted modules in a project with many of them.

Anyways, this is just one opinion, and I'm curious what others think -- because I'm sure there was some discussion about it before I got on the scene.

By the way, this is a very beautiful project you've put together here. Bravo!