### PR TITLE
Fix broken link in 1/C4

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -8,7 +8,7 @@ contributors:
   - Pieter Hintjens <ph@imatix.com>
 ---
 
-The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 2 of the C4 specification.
+The Collective Code Construction Contract (C4) is an evolution of the [Fork + Pull Model](http://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow/), aimed at providing an optimal collaboration model for free software projects. This is revision 2 of the C4 specification.
 
 This RFC is equivalent (with the exception of minor cosmetic changes) to [ZeroMQ RFC 42/C4](http://rfc.zeromq.org/spec:42)
 


### PR DESCRIPTION
```
Solution: Remove 'github.com' reference (because Fork+Pull doesn't belong to
or necessitate Github in particular), and replace link with
a personal blog article detailing the process.

I'm not set on that article in particular at all; just wanted to draw
attention to it. Other possible links include but are not limited to:
- https://help.github.com/articles/about-pull-requests/
- https://www.atlassian.com/blog/git/git-branching-and-forking-in-the-enterprise-why-fork
```